### PR TITLE
feat: add null check for request model and create a new helper method

### DIFF
--- a/Services/Utilities/ModelValidator.cs
+++ b/Services/Utilities/ModelValidator.cs
@@ -14,6 +14,12 @@ public class ModelValidator
     /// <exception cref="ValidationFailedException">Thrown when the model fails validation.</exception>
     public void ValidateModel(object model)
     {
+
+        if (model == null)
+        {
+            throw CreateValidationFailure("The model cannot be null.", "Model");
+        }
+
         var validationContext = new ValidationContext(model);
 
         var validationResults = new List<ValidationResult>();
@@ -75,6 +81,21 @@ public class ModelValidator
         {
             throw ValidationFailedException.FromValidationResults(validationResults);
         }
+    }
+
+    /// <summary>
+    /// Creates a ValidationFailedException with a single validation error, simplifying the creation
+    /// of validation exceptions for common scenarios without requiring verbose ValidationResult creation.
+    /// </summary>
+    /// <param name="message">The error message describing the validation failure.</param>
+    /// <param name="propertyName">The name of the property that failed validation. If empty, defaults to "Request"
+    /// to indicate a request-level validation issue rather than a specific property.</param>
+    /// <returns>A ValidationFailedException containing a single validation error with the specified message and property.</returns>
+    public ValidationFailedException CreateValidationFailure(string message, string propertyName = "")
+    {
+        var fieldName = string.IsNullOrEmpty(propertyName) ? "Request" : propertyName;
+        var error = new ValidationResult(message, new[] { fieldName });
+        return ValidationFailedException.FromValidationResults(new[] { error });
     }
 }
 


### PR DESCRIPTION
### 1. Helper-metod i ModelValidator

#### Varför?
För att göra det enklare/mer clean att kasta en ValidationFailedException från ex. Service-layer.

#### Hur?
Skapade en helper metod "CreateValidationFailure" som skapar en ValidationFailedException med en enda validation error.


### 2. Null check för model/request i ValidateModel-metoden
#### Varför/Hur?
Kom att tänka på att ModelValidator hanterar ju model/request som är null via "ValidationContext" som throwar "ArgumentNullException". Men detta innebär för att fånga detta hade vi behövt lägga till ytterligare en ny catch i flera endpoints om vi vill kunna berätta att request/model är null.

Tänkte att om vi checkar för null innan den når ValidationContext så kan vi, när den är null, kasta en ValidationFailedException istället, så faller den naturligt med i vår catch (ValidationFailedException).

